### PR TITLE
feat: rename repo, docs, code to reflect change to todo-issuesops

### DIFF
--- a/.github/workflows/todo-issueops.yml
+++ b/.github/workflows/todo-issueops.yml
@@ -12,7 +12,7 @@ jobs:
         # No fetch-depth needed here anymore
 
       - name: 'Run TODO IssueOps'
-        uses: vesharma-dev/todo-issueops@v1
+        uses: vesharma-dev/todo-issueops@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # labels: 'todo, needs-attention'

--- a/.github/workflows/todo-issueops.yml
+++ b/.github/workflows/todo-issueops.yml
@@ -12,7 +12,7 @@ jobs:
         # No fetch-depth needed here anymore
 
       - name: 'Run TODO IssueOps'
-        uses: vesharma-dev/todo-issuesops@v0.1.0-alpha
+        uses: vesharma-dev/todo-issueops@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # labels: 'todo, needs-attention'

--- a/.github/workflows/todo-issueops.yml
+++ b/.github/workflows/todo-issueops.yml
@@ -11,8 +11,8 @@ jobs:
         uses: actions/checkout@v4
         # No fetch-depth needed here anymore
 
-      - name: 'Run TODO Bot'
-        uses: vesharma-dev/todo-bot@v0.1.0-alpha
+      - name: 'Run TODO IssueOps'
+        uses: vesharma-dev/todo-issuesops@v0.1.0-alpha
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # labels: 'todo, needs-attention'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🤖 TODO Bot
+# 🤖 TODO IssueOps
 
 [![GitHub Marketplace](https://img.shields.io/badge/GitHub-Marketplace-blue)](https://github.com/marketplace)
 [![Docker](https://img.shields.io/badge/runs%20on-Docker-blue)](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action)
@@ -19,7 +19,7 @@ A GitHub Action that automatically creates, updates, and closes GitHub issues fr
 
 ## 🚀 Quick Start
 
-Add this action to your workflow file (`.github/workflows/todo-bot.yml`):
+Add this action to your workflow file (`.github/workflows/todo-issueops.yml`):
 
 ```yaml
 name: TODO Bot
@@ -28,18 +28,18 @@ on:
     branches: [main, develop]
 
 jobs:
-  todo-bot:
+  todo-issueops:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: TODO Bot
-        uses: vesharma-dev/todo-bot@v1
+        uses: vesharma-dev/todo-issueops@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           keywords: 'TODO,FIXME,HACK,NOTE'
-          labels: 'todo-bot,enhancement'
+          labels: 'todo-issueops,enhancement'
           assignees: 'vesharma-dev'
 ```
 
@@ -76,7 +76,7 @@ Each TODO becomes a GitHub issue with:
 
 - **Title**: The TODO content
 - **Body**: File location, line number, and direct code link
-- **Labels**: Configurable (default: `todo-bot`)
+- **Labels**: Configurable (default: `todo-issueops`)
 - **Fingerprinting**: SHA-256 hash prevents duplicates
 
 ## ⚙️ Configuration
@@ -87,7 +87,7 @@ Each TODO becomes a GitHub issue with:
 | ----------- | -------------------------------------- | -------- | --------------------- |
 | `token`     | GitHub token for API access            | ✅       | `${{ github.token }}` |
 | `keywords`  | Comma-separated keywords to search for | ❌       | `TODO,FIXME`          |
-| `labels`    | Comma-separated labels for new issues  | ❌       | `todo-bot`            |
+| `labels`    | Comma-separated labels for new issues  | ❌       | `todo-issueops`       |
 | `assignees` | Comma-separated GitHub usernames       | ❌       | none                  |
 
 ### Example Configurations
@@ -96,17 +96,17 @@ Each TODO becomes a GitHub issue with:
 
 ```yaml
 - name: TODO Bot
-  uses: vesharma-dev/todo-bot@v1
+  uses: vesharma-dev/todo-issueops@v1
 ```
 
 #### Advanced Setup
 
 ```yaml
 - name: TODO Bot
-  uses: vesharma-dev/todo-bot@v1
+  uses: vesharma-dev/todo-issueops@v1
   with:
     keywords: 'TODO,FIXME,HACK,NOTE,BUG'
-    labels: 'todo-bot,technical-debt,enhancement'
+    labels: 'todo-issueops,technical-debt,enhancement'
     assignees: 'developer1,developer2'
 ```
 
@@ -188,7 +188,7 @@ For testing with actual GitHub API:
 ### Project Structure
 
 ```
-todo-bot/
+todo-issueops/
 ├── src/index.ts          # Main TypeScript logic
 ├── dist/                 # Compiled JavaScript
 ├── scripts/              # Testing scripts
@@ -245,7 +245,7 @@ This issue was automatically created from a TODO comment in the code.
 
 _This issue is managed by TODO Bot. Do not edit the fingerprint below._
 
-<!-- TODO-BOT-FINGERPRINT: a1b2c3d4e5f6g7h8 -->
+<!-- todo-issueops-FINGERPRINT: a1b2c3d4e5f6g7h8 -->
 ```
 
 ### When TODO Removed - Auto-closed
@@ -273,9 +273,9 @@ on:
 
 Create separate workflows for different teams:
 
-- `todo-bot-critical.yml` - Urgent TODOs
-- `todo-bot-frontend.yml` - UI-related TODOs
-- `todo-bot-backend.yml` - API-related TODOs
+- `todo-issueops-critical.yml` - Urgent TODOs
+- `todo-issueops-frontend.yml` - UI-related TODOs
+- `todo-issueops-backend.yml` - API-related TODOs
 
 ## 🤝 Contributing
 
@@ -291,9 +291,9 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## 📞 Support
 
-- 🐛 **Bug Reports**: [Open an issue](https://github.com/vesharma-dev/todo-bot/issues)
-- 💡 **Feature Requests**: [Open an issue](https://github.com/vesharma-dev/todo-bot/issues)
-- 📧 **Questions**: [Discussions](https://github.com/vesharma-dev/todo-bot/discussions)
+- 🐛 **Bug Reports**: [Open an issue](https://github.com/vesharma-dev/todo-issueops/issues)
+- 💡 **Feature Requests**: [Open an issue](https://github.com/vesharma-dev/todo-issueops/issues)
+- 📧 **Questions**: [Discussions](https://github.com/vesharma-dev/todo-issueops/discussions)
 
 ---
 
@@ -307,18 +307,18 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ```yaml
 - name: TODO Bot
-  uses: vesharma-dev/todo-bot@v1
+  uses: vesharma-dev/todo-issueops@v1
 ```
 
 #### Advanced Setup
 
 ```yaml
 - name: TODO Bot
-  uses: vesharma-dev/todo-bot@v1
+  uses: vesharma-dev/todo-issueops@v1
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
     keywords: 'TODO,FIXME,HACK,NOTE,BUG'
-    labels: 'todo-bot,technical-debt,enhancement'
+    labels: 'todo-issueops,technical-debt,enhancement'
     assignees: 'developer1,developer2,team-lead'
 ```
 
@@ -326,17 +326,17 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ```yaml
 - name: Frontend TODOs
-  uses: vesharma-dev/todo-bot@v1
+  uses: vesharma-dev/todo-issueops@v1
   with:
     keywords: 'TODO,FIXME'
-    labels: 'frontend,todo-bot'
+    labels: 'frontend,todo-issueops'
     assignees: 'frontend-team-lead'
 
 - name: Backend TODOs
-  uses: vesharma-dev/todo-bot@v1
+  uses: vesharma-dev/todo-issueops@v1
   with:
     keywords: 'TODO,FIXME,OPTIMIZE'
-    labels: 'backend,todo-bot'
+    labels: 'backend,todo-issueops'
     assignees: 'backend-team-lead'
 ```
 
@@ -352,8 +352,8 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ```bash
 # Clone the repository
-git clone https://github.com/vesharma-dev/todo-bot.git
-cd todo-bot
+git clone https://github.com/vesharma-dev/todo-issueops.git
+cd todo-issueops
 
 # Install dependencies
 pnpm install
@@ -368,7 +368,7 @@ pnpm test
 ### Project Structure
 
 ```
-todo-bot/
+todo-issueops/
 ├── src/
 │   └── index.ts          # Main application logic
 ├── lib/                  # Compiled JavaScript (generated)
@@ -386,10 +386,10 @@ todo-bot/
 pnpm build
 
 # Build Docker image
-docker build -t todo-bot .
+docker build -t todo-issueops .
 
 # Test locally
-docker run --rm todo-bot
+docker run --rm todo-issueops
 ```
 
 ## 📋 Example Workflow
@@ -424,7 +424,7 @@ This issue was automatically created from a TODO comment in the code.
 
 _This issue is managed by TODO Bot. Do not edit the fingerprint below._
 
-<!-- TODO-BOT-FINGERPRINT: a1b2c3d4e5f6g7h8 -->
+<!-- todo-issueops-FINGERPRINT: a1b2c3d4e5f6g7h8 -->
 ```
 
 ### 3. **When TODO is Removed** - Auto-closed
@@ -484,10 +484,10 @@ Test the Docker container locally:
 
 ```bash
 # Build Docker image
-docker build -t todo-bot-local .
+docker build -t todo-issueops-local .
 
 # Run container (requires environment setup)
-docker run --rm -e INPUT_TOKEN=test todo-bot-local
+docker run --rm -e INPUT_TOKEN=test todo-issueops-local
 ```
 
 ### Testing with Real GitHub API
@@ -566,9 +566,9 @@ on:
 
 Create separate workflows for different teams or priorities:
 
-- `todo-bot-critical.yml` - For urgent TODOs
-- `todo-bot-frontend.yml` - For UI-related TODOs
-- `todo-bot-backend.yml` - For API-related TODOs
+- `todo-issueops-critical.yml` - For urgent TODOs
+- `todo-issueops-frontend.yml` - For UI-related TODOs
+- `todo-issueops-backend.yml` - For API-related TODOs
 
 ### Development Guidelines
 
@@ -589,9 +589,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📞 Support
 
-- 🐛 **Bug Reports**: [Open an issue](https://github.com/vesharma-dev/todo-bot/issues)
-- 💡 **Feature Requests**: [Open an issue](https://github.com/vesharma-dev/todo-bot/issues)
-- 📧 **Questions**: [Discussions](https://github.com/vesharma-dev/todo-bot/discussions)
+- 🐛 **Bug Reports**: [Open an issue](https://github.com/vesharma-dev/todo-issueops/issues)
+- 💡 **Feature Requests**: [Open an issue](https://github.com/vesharma-dev/todo-issueops/issues)
+- 📧 **Questions**: [Discussions](https://github.com/vesharma-dev/todo-issueops/discussions)
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'TODO Bot'
-description: 'A github action that automatically creates, updates, and closes GitHub issues from TODO comments in your code.'
+name: 'TODO IssueOps'
+description: 'A GitHub Action that enables IssueOps by automatically creating, updating, and closing GitHub issues from TODO comments in your code.'
 author: '@vesharma-dev'
 inputs:
   token:
@@ -16,7 +16,7 @@ inputs:
   labels:
     description: 'Comma-separated list of labels to add to new issues'
     required: false
-    default: 'todo-bot'
+    default: 'todo-issueops'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "todo-bot",
+  "name": "todo-issueops",
   "version": "1.0.0",
   "description": "A GitHub action that automatically creates, updates, and closes GitHub issues from TODO comments in your code.",
   "main": "dist/index.js",

--- a/src/services/__tests__/todo.service.test.ts
+++ b/src/services/__tests__/todo.service.test.ts
@@ -56,7 +56,7 @@ describe('todo.service', () => {
       expect(inputs.token).toBe('test-token');
       expect(inputs.keywords).toEqual(['TODO', 'FIXME']);
       expect(inputs.assignees).toEqual([]);
-      expect(inputs.labels).toEqual(['todo-bot']);
+      expect(inputs.labels).toEqual(['todo-issueops']);
     });
 
     xit('should handle empty but defined inputs', () => {
@@ -197,7 +197,7 @@ describe('todo.service', () => {
     it('should return issue number if an issue with the fingerprint is found', async () => {
       const issues = [
         { number: 1, body: 'Some other issue' },
-        { number: 2, body: '<!-- TODO-BOT-FINGERPRINT: test-fingerprint -->' },
+        { number: 2, body: '<!-- TODO-IssueOps-FINGERPRINT: test-fingerprint -->' },
       ];
       mockOctokit.rest.issues.listForRepo.mockResolvedValue({ data: issues });
 
@@ -206,7 +206,7 @@ describe('todo.service', () => {
       expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalledWith({
         owner: 'owner',
         repo: 'repo',
-        labels: 'todo-bot',
+        labels: 'todo-issueops',
         state: 'open',
       });
     });
@@ -254,20 +254,20 @@ describe('todo.service', () => {
     });
 
     it('should create an issue with correct details', async () => {
-      await createIssueForTodo(mockOctokit as any, 'owner', 'repo', todo, [], ['todo-bot'], 'sha123');
+      await createIssueForTodo(mockOctokit as any, 'owner', 'repo', todo, [], ['todo-issueops'], 'sha123');
 
       expect(mockOctokit.rest.issues.create).toHaveBeenCalledWith({
         owner: 'owner',
         repo: 'repo',
         title: 'Test TODO',
-        body: expect.stringContaining('<!-- TODO-BOT-FINGERPRINT: test-fingerprint -->'),
-        labels: ['todo-bot'],
+        body: expect.stringContaining('<!-- TODO-IssueOps-FINGERPRINT: test-fingerprint -->'),
+        labels: ['todo-issueops'],
       });
       expect(core.info).toHaveBeenCalledWith('Created issue #123 for TODO: Test TODO');
     });
 
     it('should include assignees if provided', async () => {
-      await createIssueForTodo(mockOctokit as any, 'owner', 'repo', todo, ['user1'], ['todo-bot'], 'sha123');
+      await createIssueForTodo(mockOctokit as any, 'owner', 'repo', todo, ['user1'], ['todo-issueops'], 'sha123');
 
       expect(mockOctokit.rest.issues.create).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/services/todo.service.ts
+++ b/src/services/todo.service.ts
@@ -94,7 +94,7 @@ export async function findExistingIssue(
     const response = await octokit.rest.issues.listForRepo({
       owner,
       repo,
-      labels: 'todo-bot',
+      labels: 'todo-issueops',
       state: 'open',
     });
 
@@ -136,13 +136,13 @@ export async function createIssueForTodo(
 
 **File:** \`${todo.filePath}\`
 **Line:** ${todo.lineNumber}
-**TODO:** ${todo.content}
+**Task:** ${todo.content}
 
 **Link to code:** [View in repository](${codeUrl})
 
 ---
-*This issue is managed by TODO Bot. Do not edit the fingerprint below.*
-<!-- TODO-BOT-FINGERPRINT: ${todo.fingerprint} -->`;
+*This issue is managed by TODO IssueOps. Do not edit the fingerprint below.*
+<!-- TODO-IssueOps-FINGERPRINT: ${todo.fingerprint} -->`;
 
     const createIssueData: {
       owner: string;
@@ -236,8 +236,9 @@ export function getActionInputs(): ActionInputs {
   const keywordsInput = core.getInput('keywords');
   const assigneesInput = core.getInput('assignees');
   const labelsInput = core.getInput('labels');
+  const diffPayloadInput = core.getInput('diff_payload');
 
-  const keywords = (keywordsInput || 'TODO,FIXME')
+  const keywords = (keywordsInput || 'TODO,FIXME,HACK,NOTE')
     .split(',')
     .map((k: string) => k.trim())
     .filter((k: string) => k.length > 0);
@@ -245,10 +246,10 @@ export function getActionInputs(): ActionInputs {
     .split(',')
     .map((a: string) => a.trim())
     .filter((a: string) => a.length > 0);
-  const labels = (labelsInput || 'todo-bot')
+  const labels = (labelsInput || 'todo-issueops')
     .split(',')
     .map((l: string) => l.trim())
     .filter((l: string) => l.length > 0);
 
-  return { token, keywords, assignees, labels };
+  return { token, keywords, assignees, labels, diff_payload: diffPayloadInput };
 }

--- a/src/types/main.types.ts
+++ b/src/types/main.types.ts
@@ -17,6 +17,7 @@ export interface ActionInputs {
   keywords: string[];
   assignees: string[];
   labels: string[];
+  diff_payload?: string;
 }
 
 /**

--- a/src/utils/__tests__/orchestrator.test.ts
+++ b/src/utils/__tests__/orchestrator.test.ts
@@ -53,7 +53,7 @@ describe('runTodoBotOrchestrator', () => {
       token: 'test-token',
       keywords: ['TODO', 'FIXME'],
       assignees: ['test-user'],
-      labels: ['todo-bot'],
+      labels: ['todo-issueops'],
     });
 
     mockOctokit.rest.repos.compareCommits.mockResolvedValue({
@@ -96,7 +96,7 @@ describe('runTodoBotOrchestrator', () => {
       'test-repo',
       addedTodos[0],
       ['test-user'],
-      ['todo-bot'],
+      ['todo-issueops'],
       'after-sha'
     );
 


### PR DESCRIPTION
# Summary:

- Renamed todo-bot to todo-issueOps to reflect unique name needed for Github Market place
- ensured that documentation, code, tags, etc all reflected this 